### PR TITLE
fix: `StorybookConfig` type import

### DIFF
--- a/.rnstorybook/main.ts
+++ b/.rnstorybook/main.ts
@@ -1,4 +1,4 @@
-import { StorybookConfig } from "@storybook/react-native";
+import type { StorybookConfig } from "@storybook/react-native";
 
 const main: StorybookConfig = {
   stories: ["../components/**/*.stories.?(ts|tsx|js|jsx)"],


### PR DESCRIPTION
After a fresh install on the example template I was getting the following error when running `yarn storybook:ios`:

```
yarn run v1.22.22
$ cross-env EXPO_PUBLIC_STORYBOOK_ENABLED='true' expo start --ios
Starting project at /Users/rinaldi/dev/new-storybook
SyntaxError: The requested module '@storybook/react-native' does not provide an export named 'StorybookConfig'
SyntaxError: The requested module '@storybook/react-native' does not provide an export named 'StorybookConfig'
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:385:37)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:366:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1554:24)
    at Module._compile (node:internal/modules/cjs/loader:1705:5)
    at Object.loadTS [as .ts] (node:internal/modules/cjs/loader:1815:10)
    at Module.load (node:internal/modules/cjs/loader:1458:32)
    at Function._load (node:internal/modules/cjs/loader:1275:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:234:24)
    at Module.require (node:internal/modules/cjs/loader:1480:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

With my changes it ensures the import refers to a type which fixes the issue.